### PR TITLE
Add incompatible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ PT-P900W, PT-P950NW
 
 __Tested models:__ `QL-720NW`, `QL-820NWB`
 
+`RJ-3050AI` not working.
+
 (if you have tried this with other models, please update this list and send a pull request)
 
 

--- a/src/ios/BrotherPrinter.m
+++ b/src/ios/BrotherPrinter.m
@@ -452,8 +452,8 @@
             }
         }];
 
-        _ptp = [[BRPtouchPrinter alloc] initWithPrinterName:finalDeviceName interface:CONNECTION_TYPE_BLUETOOTH];
-//        [_ptp setupForBluetoothDeviceWithSerialNumber:serialNumber];
+        //_ptp = [[BRPtouchPrinter alloc] initWithPrinterName:finalDeviceName interface:CONNECTION_TYPE_BLUETOOTH];
+                [_ptp setupForBluetoothDeviceWithSerialNumber:serialNumber];
 
     } else if (isWifi == 1) {
         _ptp = [[BRPtouchPrinter alloc] initWithPrinterName:selectedDevice interface:CONNECTION_TYPE_WLAN];

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchBluetoothManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchBluetoothManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchBluetoothManager.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchDeviceInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchDeviceInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchDevice.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchNetworkManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchNetworkManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchNetwork.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrintInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrintInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrintInfo.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -69,11 +68,6 @@
 #define	EXT_PJ673_EPR			0x20
 #define EXT_PJ700_FP            0x40
 
-//  Image processing Setting
-#define HALFTONE_BINARY    0x00
-#define HALFTONE_DITHER    0x01
-#define HALFTONE_ERRDIF    0x02
-
 //　圧縮モードフラグ
 #define COMPRESS_ID         0x4D
 #define COMPRESS_DISABLED   0x00
@@ -83,6 +77,16 @@
 #define PJROLLCASE_OFF 1  //Do not user printer case
 #define PJROLLCASE_ON 2  //Use printer case with anti-curling mechanism
 #define PJROLLCASE_WITH_ANTICURL 3   // Use printer case without anti-curling mechanism
+
+//用紙種類
+#define PJ_ROLL 0x01
+#define PJ_CUT_PAPER 0x02
+
+//Print Quality
+#define PRINTQUALITY_LOW_RESOLUTION 1 // 高速
+#define PRINTQUALITY_NORMAL 2 // ノーマル(高品質)
+#define PRINTQUALITY_DOUBLE_SPEED 3 // ノーマル(高速)
+#define PRINTQUALITY_HIGH_RESOLUTION 4 // 高品質
 
 @interface BRPtouchPrintInfo : NSObject
 
@@ -118,5 +122,9 @@
 @property   (assign,nonatomic)BOOL              bPeel;
 @property   (assign,nonatomic)BOOL              bCutMark;
 @property   (assign,nonatomic)int               nLabelMargine;
+@property   (assign,nonatomic)int               nPJPaperKind;
+@property   (assign,nonatomic)int               nPrintQuality;
+@property   (assign,nonatomic)BOOL              bMode9;
+@property   (assign,nonatomic)BOOL              bRawMode;
 
 @end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinter.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinter.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinter.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/03.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,21 +12,8 @@
 
 #include "BRPtouchPrintInfo.h"
 #include "BRPtouchPrinterData.h"
+#include "BRPtouchPrinterStatus.h"
 
-//  Cut Mode
-#define FLAG_M_AUTOCUT  0x40
-#define FLAG_M_MIRROR   0x80
-
-//  拡張モード設定フラグ
-#define FLAG_K_DRAFT    0x01
-#define FLAG_K_HALFCUT  0x04
-#define FLAG_K_NOCHAIN  0x08
-#define FLAG_K_SPTAPE   0x10
-#define FLAG_K_AFTERCUT 0x20
-#define FLAG_K_HGPRINT  0x40
-#define FLAG_K_COPY     0x80
-
-//  Error Code
 #define ERROR_NONE_          0
 #define ERROR_TIMEOUT		-3
 #define ERROR_BADPAPERRES	-4
@@ -83,6 +69,7 @@
 #define ERROR_TUBE_RIBON_EMPTY_ -55
 #define ERROR_UPDATE_FRIM_NOT_SUPPORTED_ -56 // This does not occur in iOS
 #define ERROR_OS_VERSION_NOT_SUPPORTED_ -57 // This does not occur in iOS
+#define ERROR_MINIMUM_LENGTH_LIMIT_ -58
 
 //  Message value
 #define MESSAGE_START_COMMUNICATION_ 1
@@ -122,47 +109,18 @@
 #define MESSAGE_END_REMOVE_TEMPLATE_LIST_ 35
 #define MESSAGE_CANCEL_ 36
 
+
 //  Return value
 #define RET_FALSE       0
 #define RET_TRUE        1
 
 //
-typedef struct _PTSTATUSINFO {
-	Byte	byHead;						// Head mark
-	Byte	bySize;						// Size
-	Byte	byBrotherCode;				// Brother code
-	Byte	bySeriesCode;				// Serial code
-	Byte	byModelCode;				// Model code
-	Byte	byNationCode;				// Nation code
-	Byte	byFiller;					// information about cover
-	Byte	byFiller2;					// Not used
-	Byte	byErrorInf;					// Error information 1
-	Byte	byErrorInf2;				// Error information 2
-	Byte	byMediaWidth;				// Media width
-	Byte	byMediaType;				// Media type
-	Byte	byColorNum;					// The number of colors
-	Byte	byFont;						// Font
-	Byte	byJapanesFont;				// Japanese font
-	Byte	byMode;						// Mode
-	Byte	byDensity;					// Density
-	Byte	byMediaLength;				// Media Length
-	Byte	byStatusType;				// Status Type
-	Byte	byPhaseType;				// Phase type
-	Byte	byPhaseNoHi;				// Upper bytes of phase number
-	Byte	byPhaseNoLow;				// Lower bytes of phase number
-	Byte	byNoticeNo;					// Notice number
-	Byte	byExtByteNum;				// Total bytes of extended part
-    Byte	byLabelColor;				// Color of label
-	Byte	byFontColor;				// Color of font
-	Byte	byHardWareSetting[4];		// Settings of hardware
-    Byte	byNoUse[2];                 // Not Use
-} PTSTATUSINFO, *LPPTSTATUSINFO;
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, CONNECTION_TYPE) {
     CONNECTION_TYPE_WLAN,
     CONNECTION_TYPE_BLUETOOTH,
-    CONNECTION_ERROR
-} CONNECTION_TYPE;
+    CONNECTION_TYPE_ERROR
+};
 
 extern NSString *BRWLanConnectBytesWrittenNotification;
 extern NSString *BRBluetoothSessionBytesWrittenNotification;

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterData.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterData.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterData.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterKit.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterKit.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterKit.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterStatus.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Headers/BRPtouchPrinterStatus.h
@@ -1,0 +1,45 @@
+//
+//  BRPtouchPrinterStatus.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef struct _PTSTATUSINFO {
+    Byte	byHead;						// Head mark
+    Byte	bySize;						// Size
+    Byte	byBrotherCode;				// Brother code
+    Byte	bySeriesCode;				// Serial code
+    Byte	byModelCode;				// Model code
+    Byte	byNationCode;				// Nation code
+    Byte	byFiller;					// information about cover
+    Byte	byFiller2;					// Not used
+    Byte	byErrorInf;					// Error information 1
+    Byte	byErrorInf2;				// Error information 2
+    Byte	byMediaWidth;				// Media width
+    Byte	byMediaType;				// Media type
+    Byte	byColorNum;					// The number of colors
+    Byte	byFont;						// Font
+    Byte	byJapanesFont;				// Japanese font
+    Byte	byMode;						// Mode
+    Byte	byDensity;					// Density
+    Byte	byMediaLength;				// Media Length
+    Byte	byStatusType;				// Status Type
+    Byte	byPhaseType;				// Phase type
+    Byte	byPhaseNoHi;				// Upper bytes of phase number
+    Byte	byPhaseNoLow;				// Lower bytes of phase number
+    Byte	byNoticeNo;					// Notice number
+    Byte	byExtByteNum;				// Total bytes of extended part
+    Byte	byLabelColor;				// Color of label
+    Byte	byFontColor;				// Color of font
+    Byte	byHardWareSetting[4];		// Settings of hardware
+    Byte	byNoUse[2];                 // Not Use
+} PTSTATUSINFO, *LPPTSTATUSINFO;
+
+@interface BRPtouchPrinterStatus : NSObject
+@property (nonatomic) PTSTATUSINFO *statusInfo;
+@property (nonatomic) int16_t batteryLevel;
+
+@end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Resources/Info.plist
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Resources/Info.plist
@@ -19,15 +19,15 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.1.6</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>41</string>
+	<string>55</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright (C) 2012-2017 Brother Industries, Ltd. All rights reserved.</string>
+	<string>Copyright (C) 2012-2018 Brother Industries, Ltd. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBluetoothManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBluetoothManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchBluetoothManager.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchDeviceInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchDeviceInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchDevice.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchNetworkManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchNetworkManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchNetwork.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrintInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrintInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrintInfo.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -69,11 +68,6 @@
 #define	EXT_PJ673_EPR			0x20
 #define EXT_PJ700_FP            0x40
 
-//  Image processing Setting
-#define HALFTONE_BINARY    0x00
-#define HALFTONE_DITHER    0x01
-#define HALFTONE_ERRDIF    0x02
-
 //　圧縮モードフラグ
 #define COMPRESS_ID         0x4D
 #define COMPRESS_DISABLED   0x00
@@ -83,6 +77,16 @@
 #define PJROLLCASE_OFF 1  //Do not user printer case
 #define PJROLLCASE_ON 2  //Use printer case with anti-curling mechanism
 #define PJROLLCASE_WITH_ANTICURL 3   // Use printer case without anti-curling mechanism
+
+//用紙種類
+#define PJ_ROLL 0x01
+#define PJ_CUT_PAPER 0x02
+
+//Print Quality
+#define PRINTQUALITY_LOW_RESOLUTION 1 // 高速
+#define PRINTQUALITY_NORMAL 2 // ノーマル(高品質)
+#define PRINTQUALITY_DOUBLE_SPEED 3 // ノーマル(高速)
+#define PRINTQUALITY_HIGH_RESOLUTION 4 // 高品質
 
 @interface BRPtouchPrintInfo : NSObject
 
@@ -118,5 +122,9 @@
 @property   (assign,nonatomic)BOOL              bPeel;
 @property   (assign,nonatomic)BOOL              bCutMark;
 @property   (assign,nonatomic)int               nLabelMargine;
+@property   (assign,nonatomic)int               nPJPaperKind;
+@property   (assign,nonatomic)int               nPrintQuality;
+@property   (assign,nonatomic)BOOL              bMode9;
+@property   (assign,nonatomic)BOOL              bRawMode;
 
 @end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinter.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinter.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinter.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/03.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,21 +12,8 @@
 
 #include "BRPtouchPrintInfo.h"
 #include "BRPtouchPrinterData.h"
+#include "BRPtouchPrinterStatus.h"
 
-//  Cut Mode
-#define FLAG_M_AUTOCUT  0x40
-#define FLAG_M_MIRROR   0x80
-
-//  拡張モード設定フラグ
-#define FLAG_K_DRAFT    0x01
-#define FLAG_K_HALFCUT  0x04
-#define FLAG_K_NOCHAIN  0x08
-#define FLAG_K_SPTAPE   0x10
-#define FLAG_K_AFTERCUT 0x20
-#define FLAG_K_HGPRINT  0x40
-#define FLAG_K_COPY     0x80
-
-//  Error Code
 #define ERROR_NONE_          0
 #define ERROR_TIMEOUT		-3
 #define ERROR_BADPAPERRES	-4
@@ -83,6 +69,7 @@
 #define ERROR_TUBE_RIBON_EMPTY_ -55
 #define ERROR_UPDATE_FRIM_NOT_SUPPORTED_ -56 // This does not occur in iOS
 #define ERROR_OS_VERSION_NOT_SUPPORTED_ -57 // This does not occur in iOS
+#define ERROR_MINIMUM_LENGTH_LIMIT_ -58
 
 //  Message value
 #define MESSAGE_START_COMMUNICATION_ 1
@@ -122,47 +109,18 @@
 #define MESSAGE_END_REMOVE_TEMPLATE_LIST_ 35
 #define MESSAGE_CANCEL_ 36
 
+
 //  Return value
 #define RET_FALSE       0
 #define RET_TRUE        1
 
 //
-typedef struct _PTSTATUSINFO {
-	Byte	byHead;						// Head mark
-	Byte	bySize;						// Size
-	Byte	byBrotherCode;				// Brother code
-	Byte	bySeriesCode;				// Serial code
-	Byte	byModelCode;				// Model code
-	Byte	byNationCode;				// Nation code
-	Byte	byFiller;					// information about cover
-	Byte	byFiller2;					// Not used
-	Byte	byErrorInf;					// Error information 1
-	Byte	byErrorInf2;				// Error information 2
-	Byte	byMediaWidth;				// Media width
-	Byte	byMediaType;				// Media type
-	Byte	byColorNum;					// The number of colors
-	Byte	byFont;						// Font
-	Byte	byJapanesFont;				// Japanese font
-	Byte	byMode;						// Mode
-	Byte	byDensity;					// Density
-	Byte	byMediaLength;				// Media Length
-	Byte	byStatusType;				// Status Type
-	Byte	byPhaseType;				// Phase type
-	Byte	byPhaseNoHi;				// Upper bytes of phase number
-	Byte	byPhaseNoLow;				// Lower bytes of phase number
-	Byte	byNoticeNo;					// Notice number
-	Byte	byExtByteNum;				// Total bytes of extended part
-    Byte	byLabelColor;				// Color of label
-	Byte	byFontColor;				// Color of font
-	Byte	byHardWareSetting[4];		// Settings of hardware
-    Byte	byNoUse[2];                 // Not Use
-} PTSTATUSINFO, *LPPTSTATUSINFO;
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, CONNECTION_TYPE) {
     CONNECTION_TYPE_WLAN,
     CONNECTION_TYPE_BLUETOOTH,
-    CONNECTION_ERROR
-} CONNECTION_TYPE;
+    CONNECTION_TYPE_ERROR
+};
 
 extern NSString *BRWLanConnectBytesWrittenNotification;
 extern NSString *BRBluetoothSessionBytesWrittenNotification;

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterData.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterData.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterData.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterKit.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterKit.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterKit.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterStatus.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterStatus.h
@@ -1,0 +1,45 @@
+//
+//  BRPtouchPrinterStatus.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef struct _PTSTATUSINFO {
+    Byte	byHead;						// Head mark
+    Byte	bySize;						// Size
+    Byte	byBrotherCode;				// Brother code
+    Byte	bySeriesCode;				// Serial code
+    Byte	byModelCode;				// Model code
+    Byte	byNationCode;				// Nation code
+    Byte	byFiller;					// information about cover
+    Byte	byFiller2;					// Not used
+    Byte	byErrorInf;					// Error information 1
+    Byte	byErrorInf2;				// Error information 2
+    Byte	byMediaWidth;				// Media width
+    Byte	byMediaType;				// Media type
+    Byte	byColorNum;					// The number of colors
+    Byte	byFont;						// Font
+    Byte	byJapanesFont;				// Japanese font
+    Byte	byMode;						// Mode
+    Byte	byDensity;					// Density
+    Byte	byMediaLength;				// Media Length
+    Byte	byStatusType;				// Status Type
+    Byte	byPhaseType;				// Phase type
+    Byte	byPhaseNoHi;				// Upper bytes of phase number
+    Byte	byPhaseNoLow;				// Lower bytes of phase number
+    Byte	byNoticeNo;					// Notice number
+    Byte	byExtByteNum;				// Total bytes of extended part
+    Byte	byLabelColor;				// Color of label
+    Byte	byFontColor;				// Color of font
+    Byte	byHardWareSetting[4];		// Settings of hardware
+    Byte	byNoUse[2];                 // Not Use
+} PTSTATUSINFO, *LPPTSTATUSINFO;
+
+@interface BRPtouchPrinterStatus : NSObject
+@property (nonatomic) PTSTATUSINFO *statusInfo;
+@property (nonatomic) int16_t batteryLevel;
+
+@end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Resources/Info.plist
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/A/Resources/Info.plist
@@ -19,15 +19,15 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.1.6</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>41</string>
+	<string>55</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright (C) 2012-2017 Brother Industries, Ltd. All rights reserved.</string>
+	<string>Copyright (C) 2012-2018 Brother Industries, Ltd. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchBluetoothManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchBluetoothManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchBluetoothManager.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchDeviceInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchDeviceInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchDevice.h
 //  BRSearchModule
 //
-//  Created by Sha Peng on 6/22/15.
-//  Copyright (c) 2015 Brother. All rights reserved.
+//  Copyright (c) 2017 Brother. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchNetworkManager.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchNetworkManager.h
@@ -2,8 +2,7 @@
 //  BRPtouchNetwork.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrintInfo.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrintInfo.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrintInfo.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -69,11 +68,6 @@
 #define	EXT_PJ673_EPR			0x20
 #define EXT_PJ700_FP            0x40
 
-//  Image processing Setting
-#define HALFTONE_BINARY    0x00
-#define HALFTONE_DITHER    0x01
-#define HALFTONE_ERRDIF    0x02
-
 //　圧縮モードフラグ
 #define COMPRESS_ID         0x4D
 #define COMPRESS_DISABLED   0x00
@@ -83,6 +77,16 @@
 #define PJROLLCASE_OFF 1  //Do not user printer case
 #define PJROLLCASE_ON 2  //Use printer case with anti-curling mechanism
 #define PJROLLCASE_WITH_ANTICURL 3   // Use printer case without anti-curling mechanism
+
+//用紙種類
+#define PJ_ROLL 0x01
+#define PJ_CUT_PAPER 0x02
+
+//Print Quality
+#define PRINTQUALITY_LOW_RESOLUTION 1 // 高速
+#define PRINTQUALITY_NORMAL 2 // ノーマル(高品質)
+#define PRINTQUALITY_DOUBLE_SPEED 3 // ノーマル(高速)
+#define PRINTQUALITY_HIGH_RESOLUTION 4 // 高品質
 
 @interface BRPtouchPrintInfo : NSObject
 
@@ -118,5 +122,9 @@
 @property   (assign,nonatomic)BOOL              bPeel;
 @property   (assign,nonatomic)BOOL              bCutMark;
 @property   (assign,nonatomic)int               nLabelMargine;
+@property   (assign,nonatomic)int               nPJPaperKind;
+@property   (assign,nonatomic)int               nPrintQuality;
+@property   (assign,nonatomic)BOOL              bMode9;
+@property   (assign,nonatomic)BOOL              bRawMode;
 
 @end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinter.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinter.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinter.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/03.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,21 +12,8 @@
 
 #include "BRPtouchPrintInfo.h"
 #include "BRPtouchPrinterData.h"
+#include "BRPtouchPrinterStatus.h"
 
-//  Cut Mode
-#define FLAG_M_AUTOCUT  0x40
-#define FLAG_M_MIRROR   0x80
-
-//  拡張モード設定フラグ
-#define FLAG_K_DRAFT    0x01
-#define FLAG_K_HALFCUT  0x04
-#define FLAG_K_NOCHAIN  0x08
-#define FLAG_K_SPTAPE   0x10
-#define FLAG_K_AFTERCUT 0x20
-#define FLAG_K_HGPRINT  0x40
-#define FLAG_K_COPY     0x80
-
-//  Error Code
 #define ERROR_NONE_          0
 #define ERROR_TIMEOUT		-3
 #define ERROR_BADPAPERRES	-4
@@ -83,6 +69,7 @@
 #define ERROR_TUBE_RIBON_EMPTY_ -55
 #define ERROR_UPDATE_FRIM_NOT_SUPPORTED_ -56 // This does not occur in iOS
 #define ERROR_OS_VERSION_NOT_SUPPORTED_ -57 // This does not occur in iOS
+#define ERROR_MINIMUM_LENGTH_LIMIT_ -58
 
 //  Message value
 #define MESSAGE_START_COMMUNICATION_ 1
@@ -122,47 +109,18 @@
 #define MESSAGE_END_REMOVE_TEMPLATE_LIST_ 35
 #define MESSAGE_CANCEL_ 36
 
+
 //  Return value
 #define RET_FALSE       0
 #define RET_TRUE        1
 
 //
-typedef struct _PTSTATUSINFO {
-	Byte	byHead;						// Head mark
-	Byte	bySize;						// Size
-	Byte	byBrotherCode;				// Brother code
-	Byte	bySeriesCode;				// Serial code
-	Byte	byModelCode;				// Model code
-	Byte	byNationCode;				// Nation code
-	Byte	byFiller;					// information about cover
-	Byte	byFiller2;					// Not used
-	Byte	byErrorInf;					// Error information 1
-	Byte	byErrorInf2;				// Error information 2
-	Byte	byMediaWidth;				// Media width
-	Byte	byMediaType;				// Media type
-	Byte	byColorNum;					// The number of colors
-	Byte	byFont;						// Font
-	Byte	byJapanesFont;				// Japanese font
-	Byte	byMode;						// Mode
-	Byte	byDensity;					// Density
-	Byte	byMediaLength;				// Media Length
-	Byte	byStatusType;				// Status Type
-	Byte	byPhaseType;				// Phase type
-	Byte	byPhaseNoHi;				// Upper bytes of phase number
-	Byte	byPhaseNoLow;				// Lower bytes of phase number
-	Byte	byNoticeNo;					// Notice number
-	Byte	byExtByteNum;				// Total bytes of extended part
-    Byte	byLabelColor;				// Color of label
-	Byte	byFontColor;				// Color of font
-	Byte	byHardWareSetting[4];		// Settings of hardware
-    Byte	byNoUse[2];                 // Not Use
-} PTSTATUSINFO, *LPPTSTATUSINFO;
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, CONNECTION_TYPE) {
     CONNECTION_TYPE_WLAN,
     CONNECTION_TYPE_BLUETOOTH,
-    CONNECTION_ERROR
-} CONNECTION_TYPE;
+    CONNECTION_TYPE_ERROR
+};
 
 extern NSString *BRWLanConnectBytesWrittenNotification;
 extern NSString *BRBluetoothSessionBytesWrittenNotification;

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterData.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterData.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterData.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/06/26.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterKit.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterKit.h
@@ -2,8 +2,7 @@
 //  BRPtouchPrinterKit.h
 //  BRPtouchPrinterKit
 //
-//  Created by BIL on 12/02/23.
-//  Copyright (c) 2012 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterStatus.h
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Headers/BRPtouchPrinterStatus.h
@@ -1,0 +1,45 @@
+//
+//  BRPtouchPrinterStatus.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef struct _PTSTATUSINFO {
+    Byte	byHead;						// Head mark
+    Byte	bySize;						// Size
+    Byte	byBrotherCode;				// Brother code
+    Byte	bySeriesCode;				// Serial code
+    Byte	byModelCode;				// Model code
+    Byte	byNationCode;				// Nation code
+    Byte	byFiller;					// information about cover
+    Byte	byFiller2;					// Not used
+    Byte	byErrorInf;					// Error information 1
+    Byte	byErrorInf2;				// Error information 2
+    Byte	byMediaWidth;				// Media width
+    Byte	byMediaType;				// Media type
+    Byte	byColorNum;					// The number of colors
+    Byte	byFont;						// Font
+    Byte	byJapanesFont;				// Japanese font
+    Byte	byMode;						// Mode
+    Byte	byDensity;					// Density
+    Byte	byMediaLength;				// Media Length
+    Byte	byStatusType;				// Status Type
+    Byte	byPhaseType;				// Phase type
+    Byte	byPhaseNoHi;				// Upper bytes of phase number
+    Byte	byPhaseNoLow;				// Lower bytes of phase number
+    Byte	byNoticeNo;					// Notice number
+    Byte	byExtByteNum;				// Total bytes of extended part
+    Byte	byLabelColor;				// Color of label
+    Byte	byFontColor;				// Color of font
+    Byte	byHardWareSetting[4];		// Settings of hardware
+    Byte	byNoUse[2];                 // Not Use
+} PTSTATUSINFO, *LPPTSTATUSINFO;
+
+@interface BRPtouchPrinterStatus : NSObject
+@property (nonatomic) PTSTATUSINFO *statusInfo;
+@property (nonatomic) int16_t batteryLevel;
+
+@end

--- a/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Resources/Info.plist
+++ b/src/ios/libs/BRPtouchPrinterKit.framework/Versions/Current/Resources/Info.plist
@@ -19,15 +19,15 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.1.6</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>41</string>
+	<string>55</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright (C) 2012-2017 Brother Industries, Ltd. All rights reserved.</string>
+	<string>Copyright (C) 2012-2018 Brother Industries, Ltd. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
My app is crashing (RJ-3050Ai). Any luck fixing this @VictorCoding @gordol ?  Here is report;

```
Last Exception Backtrace:
0   CoreFoundation                	0x18572f164 __exceptionPreprocess + 124
1   libobjc.A.dylib               	0x184978528 objc_exception_throw + 55
2   CoreFoundation                	0x18572f0ac +[NSException raise:format:] + 115
3   CoreFoundation                	0x1856c5ae8 mutateError + 203
4   hello                         	0x10286cf08 -[BRPtouchPrinter setPrinterName:] + 413448 (BRPtouchPrinter.mm:520)
5   hello                         	0x10286cc54 -[BRPtouchPrinter initWithPrinterName:] + 412756 (BRPtouchPrinter.mm:420)
6   hello                         	0x10286cc88 -[BRPtouchPrinter initWithPrinterName:interface:] + 412808 (BRPtouchPrinter.mm:429)
7   hello                         	0x102843768 -[BrotherPrinter printViaSDK:] + 243560 (BrotherPrinter.m:455)
```

```
Thread 0 name:  Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   libsystem_kernel.dylib        	0x00000001852442e8 __pthread_kill + 8
1   libsystem_pthread.dylib       	0x000000018535d748 pthread_kill$VARIANT$armv81 + 360
2   libsystem_c.dylib             	0x00000001851b2fbc abort + 140
3   libc++abi.dylib               	0x0000000184950068 __cxa_bad_cast + 0
4   libc++abi.dylib               	0x0000000184950210 default_unexpected_handler+ 8720 () + 0
5   libobjc.A.dylib               	0x0000000184978810 _objc_terminate+ 34832 () + 124
6   libc++abi.dylib               	0x000000018496854c std::__terminate(void (*)+ 107852 ()) + 16
7   libc++abi.dylib               	0x0000000184967ea8 __cxxabiv1::exception_cleanup_func+ 106152 (_Unwind_Reason_Code, _Unwind_Exception*) + 0
8   libobjc.A.dylib               	0x000000018497865c _objc_exception_destructor+ 34396 (void*) + 0
9   CoreFoundation                	0x000000018572f0ac -[NSException initWithCoder:] + 0
10  CoreFoundation                	0x00000001856c5ae8 mutateError + 204
11  hello                         	0x000000010286cf08 -[BRPtouchPrinter setPrinterName:] + 413448 (BRPtouchPrinter.mm:523)
12  hello                         	0x000000010286cc54 -[BRPtouchPrinter initWithPrinterName:] + 412756 (BRPtouchPrinter.mm:420)
13  hello                         	0x000000010286cc88 -[BRPtouchPrinter initWithPrinterName:interface:] + 412808 (BRPtouchPrinter.mm:429)
14  hello                         	0x0000000102843768 -[BrotherPrinter printViaSDK:] + 243560 (BrotherPrinter.m:455)
```